### PR TITLE
Add a fallback button on TVs

### DIFF
--- a/app/src/main/java/de/saschawillems/glescapsviewer/GLActivity.java
+++ b/app/src/main/java/de/saschawillems/glescapsviewer/GLActivity.java
@@ -25,6 +25,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.opengl.GLSurfaceView;
 import android.os.Bundle;
@@ -35,7 +36,9 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.widget.Button;
 import android.widget.EditText;
+import android.widget.PopupMenu;
 import android.widget.TableLayout;
 import android.widget.TextView;
 
@@ -73,9 +76,23 @@ public class GLActivity extends Activity implements PropertyChangeListener {
 	
 		mGLSurfaceView.setRenderer(mRenderer);
 	    mGLSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
-	    
+
+           // For TVs, put an alternative button on UI to upload reports
+           boolean isTv = getPackageManager().hasSystemFeature(PackageManager.FEATURE_LEANBACK);
+           Button menuButton = findViewById(R.id.button_second_menu);
+           if(isTv) {
+             menuButton.setOnClickListener(v -> showPopupMenu(v));
+           } else {
+             menuButton.setVisibility(View.GONE);
+           }
 	}
 	
+        private void showPopupMenu(View anchorView) {
+            PopupMenu popupMenu = new PopupMenu(this, anchorView);
+            popupMenu.getMenuInflater().inflate(R.menu.main_activity_actions, popupMenu.getMenu());
+            popupMenu.setOnMenuItemClickListener(this::onOptionsItemSelected);
+            popupMenu.show();
+        }
 	
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {

--- a/app/src/main/res/layout/activity_gl.xml
+++ b/app/src/main/res/layout/activity_gl.xml
@@ -3,6 +3,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     
+    <Button
+        android:id="@+id/button_second_menu"
+        android:text="@string/action_settings"
+        android:focusable="true"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+    />
     <!-- Here is where we put the SurfaceView, in a frame so that we can
          stack other views on top of it. -->
     <FrameLayout


### PR DESCRIPTION
Hi - i'm sending a draft PR with a quick hack to make this app work on Leanback / TV launchers.

Just tried it out here: https://opengles.gpuinfo.org/displayreport.php?id=7669

I think this probably isn't the best / most correct way to do this on TVs, but i couldn't figure out how to get the menu to show otherwise, short of switching everything to Leanback and/or bring in AppCompat frameworks and such.

I'm happy to re-work / clean up if there's a better suggested way to do it !